### PR TITLE
fix: scan_count & is_paired handling for faster reconnect

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -288,11 +288,13 @@ RoonApi.prototype.init_services = function(o) {
 
 		    this.paired_core_id = core.core_id;
                     this.paired_core = core;
-                    this.is_paired = true;
 		    svc.send_continue_all("subscribe_pairing", "Changed", { paired_core_id: this.paired_core_id  })
 		}
-		if (core.core_id == this.paired_core_id)
+	    if (core.core_id == this.paired_core_id) {
+		    // make sure the periodic_scan is stopped after a re-connection to the same core
+		    this.is_paired = true;
 		    if (this.extension_opts.core_paired) this.extension_opts.core_paired(core);
+	    }
 	    },
 	    lost_core: core => {
 		if (core.core_id == this.paired_core_id)
@@ -402,6 +404,7 @@ RoonApi.prototype.ws_connect = function({ host, port, onclose, onerror }) {
 
     moo.transport.onopen = () => {
         //        this.logger.log("OPEN");
+        this.scan_count = -1;
 
         moo.send_request("com.roonlabs.registry:1/info",
 			     (msg, body) => {
@@ -418,6 +421,9 @@ RoonApi.prototype.ws_connect = function({ host, port, onclose, onerror }) {
 
     moo.transport.onclose = () => {
 //        this.logger.log("CLOSE");
+        // reset scan count for faster reconnect
+        this.scan_count = -1;
+
         Object.keys(this._service_request_handlers).forEach(e => this._service_request_handlers[e] && this._service_request_handlers[e](null, moo.mooid));
         moo.clean_up();
         onclose && onclose();


### PR DESCRIPTION
If the connection to the Roon core drops and has been re-established, the scan function is not stopped. The reason is that the `is_paired` flag is only set at the very first Roon core connection, reset at disconnection, but then never set again.

The `paired_core_id` logic is left as is. My understanding is, that the API always connects to the same Core again, in case multiple Cores are available.
If that's not the intention, then the whole logic could be simplified.

Furthermore, the `scan_count` counter is reset after a connection has been established or closed. This allows for faster reconnections, where this API is used on devices not having permanent connections to the Roon Core.
Otherwise only the initial 6 scans are performed every 10 seconds, then only every 60 seconds. This can lead to poor user experience for use cases where either the WiFi connection drops, or if the client device is battery powered and goes into standby.

Discovered in: unfoldedcircle/integration-roon#56