### PR TITLE
feat: add disconnect_all & stop_discovery to RoonApi

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -109,6 +109,8 @@ function RoonApi(o) {
     this.extension_opts = o;
     this.is_paired = false;
     this.configDir = o.configDir;
+    this.scan_count = -1;
+    this.scanIntervalId = 0;
 
     // - pull in Sood and provide discovery methods in Node, but not in WebBrowser
     //
@@ -121,48 +123,88 @@ function RoonApi(o) {
         * Begin the discovery process to find/connect to a Roon Core.
         */
         RoonApi.prototype.start_discovery = function() {
-            if (this._sood) return;
-            this._sood = require('./sood.js')(this.logger);
-            this._sood_conns = {};
-            this._sood.on('message', msg => {
-                //this.logger.log(msg);
-                if (msg.props.service_id == "00720724-5143-4a9b-abac-0e50cba674bb" && msg.props.unique_id) {
-                    if (this._sood_conns[msg.props.unique_id]) {
-                        return;
-                    }
+            // check if discovery needs to be restarted after stop_discovery has been called
+            if (this._sood) {
+                if (this.scanIntervalId) {
+                    // ignore, function called multiple times without stop_discovery
+                    return;
+                }
+            } else {
+                // first start_discovery call: setup everything
+                this.logger.log("Setting up sood");
+                this._sood = require('./sood.js')(this.logger);
+                this._sood_conns = {};
+                this._sood.on('message', msg => {
+                    //this.logger.log(msg);
+                    if (msg.props.service_id === "00720724-5143-4a9b-abac-0e50cba674bb" && msg.props.unique_id) {
+                        if (this._sood_conns[msg.props.unique_id]) {
+                            return;
+                        }
 
-                    let ip = msg.from.ip;
-                    let ni = os.networkInterfaces();
-                    for (let prot in ni) {
-                        for (let addr of ni[prot]) {
-                            if (ip === addr.address) {
-                                ip = '127.0.0.1';
-                                break
+                        let ip = msg.from.ip;
+                        let ni = os.networkInterfaces();
+                        for (let prot in ni) {
+                            for (let addr of ni[prot]) {
+                                if (ip === addr.address) {
+                                    ip = '127.0.0.1';
+                                    break
+                                }
                             }
                         }
-                    }
 
-                    this._sood_conns[msg.props.unique_id] = this.ws_connect({
-                        host: ip,
-                        port: msg.props.http_port,
-                        onclose: () => {
-                            delete(this._sood_conns[msg.props.unique_id]);
-                        },
-                        onerror: (moo) => {
-                            if (this.extension_opts.moo_onerror) this.extension_opts.moo_onerror(moo);
-                        }
-                    });
-                }
-            });
-            this._sood.on('network', () => {
-                this._sood.query({ query_service_id: "00720724-5143-4a9b-abac-0e50cba674bb" });
-            });
+                        this._sood_conns[msg.props.unique_id] = this.ws_connect({
+                            host: ip,
+                            port: msg.props.http_port,
+                            onclose: () => {
+                                delete(this._sood_conns[msg.props.unique_id]);
+                            },
+                            onerror: (moo) => {
+                                if (this.extension_opts.moo_onerror) this.extension_opts.moo_onerror(moo);
+                            }
+                        });
+                    }
+                });
+                this._sood.on('network', () => {
+                    this._sood.query({ query_service_id: "00720724-5143-4a9b-abac-0e50cba674bb" });
+                });
+            }
+
+            this.logger.log("Starting sood");
             this._sood.start(() => {
                 this._sood.query({ query_service_id: "00720724-5143-4a9b-abac-0e50cba674bb" });
-                setInterval(() => this.periodic_scan(), (10 * 1000));
+                this.scanIntervalId = setInterval(() => this.periodic_scan(), (10 * 1000));
                 this.scan_count = -1;
             });
         };
+
+        /**
+         * Stop the discovery process to automatically connect to a Roon core.
+         *
+         * To restart the discovery process, call `start_discovery` again.
+         */
+        RoonApi.prototype.stop_discovery = function() {
+            if (this.scanIntervalId) {
+                clearInterval(this.scanIntervalId);
+                this.scanIntervalId = 0;
+            }
+            if (this._sood) {
+                this._sood.stop();
+            }
+        }
+
+        /**
+         * Disconnect all Roon core WebSocket connections.
+         *
+         * To remain disconnected, call `stop_discovery` first.
+         */
+        RoonApi.prototype.disconnect_all = function() {
+            if (this._sood_conns) {
+                Object.entries(this._sood_conns).forEach(([id, conn]) => {
+                    this.logger.log("Closing Roon connection: %s", id);
+                    conn.transport.close();
+                });
+            }
+        }
 
         RoonApi.prototype.periodic_scan = function() {
             this.scan_count += 1;

--- a/sood.js
+++ b/sood.js
@@ -19,6 +19,7 @@ function Sood(logger) {
     this._unicast = {};
     this._iface_seq = 0;
     this.logger = logger;
+    this.interface_timer = 0;
 //    this.on("message", (msg) => { this.logger.log(JSON.stringify(msg)); });
 };
 
@@ -162,9 +163,8 @@ Sood.prototype.start = function(cb) {
     this.initsocket(cb);
 };
 Sood.prototype.stop = function() {
-    if (this.interface_timer) clearInterval(interface_timer);
-    delete(this.interface_timer);
-    for (ip in this._multicast) {
+    if (this.interface_timer) clearInterval(this.interface_timer);
+    for (const ip in this._multicast) {
 	try { this._multicast[ip].recv_sock.close(); } catch (e) { }
 	try { this._multicast[ip].send_sock.close(); } catch (e) { }
     }

--- a/transport-websocket.js
+++ b/transport-websocket.js
@@ -42,7 +42,10 @@ function Transport(ip, port, logger) {
     }
 
     this.ws.onmessage = (event) => {
-        var msg = this.moo.parse(event.data);
+        if (!this.moo) {
+            return;
+        }
+        const msg = this.moo.parse(event.data);
         if (!msg) {
             this.close();
             return;
@@ -57,6 +60,7 @@ Transport.prototype.send = function(buf) {
 
 Transport.prototype.close = function() {
     if (this.ws) {
+        clearInterval(this.interval);
         this.ws.close();
         this.ws = undefined;
     }


### PR DESCRIPTION
New API methods to disconnect and remain disconnected from Roon core. This can be useful for not-always connected clients, especially for battery powered devices supporting standby.

This allows to disconnect from Roon before entering standby, and immediately reconnect after waking up (if the client has access to standby events), significantly speeding up the reconnection time.

The old logic can take up to a minute to reconnect, whereas manually disconnecting & reconnecting usually takes less than 1-2 seconds.

Required for: unfoldedcircle/integration-roon#56