### PR TITLE
refactor: replace custom logging with debug module

### DIFF
--- a/loggers.js
+++ b/loggers.js
@@ -1,0 +1,17 @@
+/**
+ * Central log functions.
+ *
+ * Use [debug](https://www.npmjs.com/package/debug) module for logging.
+ */
+
+const debug = require("debug");
+
+const log = {
+  msgTrace: debug("roonapi:msg"),
+  debug: debug("roonapi:debug"),
+  info: debug("roonapi:info"),
+  warn: debug("roonapi:warn"),
+  error: debug("roonapi:error")
+};
+
+exports = module.exports = log;

--- a/moomsg.js
+++ b/moomsg.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const log = require('./loggers.js');
+
 function MooMessage(moo, msg, body) {
     this.moo = moo;
     this.msg = msg;
@@ -11,9 +13,9 @@ MooMessage.prototype.send_continue = function() {
     var body;
     var content_type;
 
-    if (arguments.length == 1) {
+    if (arguments.length === 1) {
         name = arguments[0];
-    } else if (arguments.length == 2) {
+    } else if (arguments.length === 2) {
         name = arguments[0];
         body = arguments[1];
     } else if (arguments.length >= 3) {
@@ -41,12 +43,15 @@ MooMessage.prototype.send_continue = function() {
                   'Content-Type: ' + content_type + '\n';
     }
 
-    if (this.msg.log) this.moo.logger.log('-> CONTINUE', this.msg.request_id, name, origbody ? JSON.stringify(origbody) : "");
+    if (log.msgTrace.enabled) {
+        log.msgTrace('-> CONTINUE', this.msg.request_id, name, origbody ? JSON.stringify(origbody) : "");
+    }
     const m = Buffer.from(header + '\n');
-    if (body)
-        this.moo.transport.send(Buffer.concat([ m, body ], m.length + body.length));
-    else
+    if (body) {
+        this.moo.transport.send(Buffer.concat([m, body], m.length + body.length));
+    } else {
         this.moo.transport.send(m);
+    }
 };
 
 MooMessage.prototype.send_complete = function() {
@@ -54,9 +59,9 @@ MooMessage.prototype.send_complete = function() {
     var body;
     var content_type;
 
-    if (arguments.length == 1) {
+    if (arguments.length === 1) {
         name = arguments[0];
-    } else if (arguments.length == 2) {
+    } else if (arguments.length === 2) {
         name = arguments[0];
         body = arguments[1];
     } else if (arguments.length >= 3) {
@@ -84,12 +89,15 @@ MooMessage.prototype.send_complete = function() {
                   'Content-Type: ' + content_type + '\n';
     }
 
-    if (this.msg.log) this.moo.logger.log('-> COMPLETE', this.msg.request_id, name, origbody ? JSON.stringify(origbody) : "");
+    if (log.msgTrace.enabled) {
+        log.msgTrace('-> COMPLETE', this.msg.request_id, name, origbody ? JSON.stringify(origbody) : "");
+    }
     const m = Buffer.from(header + '\n');
-    if (body)
-        this.moo.transport.send(Buffer.concat([ m, body ], m.length + body.length));
-    else
+    if (body) {
+        this.moo.transport.send(Buffer.concat([m, body], m.length + body.length));
+    } else {
         this.moo.transport.send(m);
+    }
 };
 
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Roon Labs, LLC",
   "license": "Apache-2.0",
   "dependencies": {
+    "debug": "^4.4.0",
     "ip": "^2.0.1",
     "node-uuid": "^1.4.8",
     "ws": ">=3.3.1"

--- a/sood.js
+++ b/sood.js
@@ -4,24 +4,24 @@ SOOD implements Roon Core discovery using UDP protocol
 
 "use strict";
 
-var util    = require("util"),
+const util    = require("util"),
     events  = require('events'),
     dgram   = require('dgram'),
     IP      = require('ip'),
     uuid    = require('node-uuid'),
-    os      = require('os');
+    os      = require('os'),
+    log = require('./loggers.js');
 
 var SOOD_PORT         = 9003;
 var SOOD_MULTICAST_IP = "239.255.90.90";
 
-function Sood(logger) {
+function Sood() {
     this._multicast = {};
     this._unicast = {};
     this._iface_seq = 0;
-    this.logger = logger;
     this.interface_timer = 0;
-//    this.on("message", (msg) => { this.logger.log(JSON.stringify(msg)); });
-};
+//    this.on("message", (msg) => { log.msgTrace(JSON.stringify(msg)); });
+}
 
 util.inherits(Sood, events.EventEmitter);
 
@@ -35,13 +35,13 @@ function _parse(buf, minfo) {
 	props: {},
     };
     try {
-	if (buf.toString('utf8', 0, 4) != 'SOOD') return null;
-	if (buf[4] != 2) return null;
+	if (buf.toString('utf8', 0, 4) !== 'SOOD') return null;
+	if (buf[4] !== 2) return null;
 	msg.type = buf.toString('utf8', 5, 6);
 	let pos = 6;
 	while (pos < buf.length) {
 	    let len = buf[pos++];
-	    if (len == 0) return null;
+	    if (len === 0) return null;
 	    if (pos + len > buf.length) return null;
 	    let name = buf.toString('utf8', pos, pos+len);
 	    pos += len;
@@ -49,9 +49,9 @@ function _parse(buf, minfo) {
 	    len |= buf[pos++];
 
 	    let val;
-	    if (len == 65535)
+	    if (len === 65535)
 		val = null;
-	    else if (len == 0)
+	    else if (len === 0)
 		val = "";
 	    else {
 		if (pos + len > buf.length) return null;
@@ -103,14 +103,14 @@ Sood.prototype.query = function(msg) {
 
     for (var ip in this._multicast) {
 	if (this._multicast[ip].send_sock) {
-//	    this.logger.log('sending on mcast ' + ip);
+//	    log.debug('sending on mcast ' + ip);
 	    this._multicast[ip].send_sock.send(buf, 0, pos, SOOD_PORT, SOOD_MULTICAST_IP);
-//	    this.logger.log('sending on mcast ' + ip + ", bcast " + this._multicast[ip].broadcast);
+//	    log.debug('sending on mcast ' + ip + ", bcast " + this._multicast[ip].broadcast);
 	    this._multicast[ip].send_sock.send(buf, 0, pos, SOOD_PORT, this._multicast[ip].broadcast);
 	}
     }
     if (this._unicast.send_sock) {
-//	this.logger.log('sending on unicast');
+//	log.debug('sending on unicast');
 	this._unicast.send_sock.send(buf, 0, pos, SOOD_PORT, SOOD_MULTICAST_IP);
     }
 };
@@ -121,13 +121,13 @@ Sood.prototype.initsocket = function(cb) {
     var iface_change = false;
     for (var iface in list) {
         list[iface].forEach(e => {
-            if (e.family == 'IPv4')
+            if (e.family === 'IPv4')
                 iface_change = this._listen_iface(e.address, e.netmask, iface) || iface_change;
         });
     }
 
     for (var ip in this._multicast) {
-        if (this._multicast[ip].seq != this._iface_seq) {
+        if (this._multicast[ip].seq !== this._iface_seq) {
             delete this._multicast[ip];
             iface_change = true;
         }
@@ -135,14 +135,14 @@ Sood.prototype.initsocket = function(cb) {
 
     let unicast = this._unicast;
     if (!unicast.send_sock) {
-        //	    this.logger.log(`SOOD: new sock: unicast`);
+        //	    log.debug(`SOOD: new sock: unicast`);
         unicast.send_sock = dgram.createSocket({ type: 'udp4' });
         unicast.send_sock.on('error', (err) => {
-            //		this.logger.log(`server error ${ip}`, err);
+            //		log.debug(`server error ${ip}`, err);
             unicast.send_sock.close();
         });
         unicast.send_sock.on('close', () => {
-            //		this.logger.log(`closed unicast on ${ip}`);
+            //		log.debug(`closed unicast on ${ip}`);
             delete(unicast.send_sock);
         });
         unicast.send_sock.on('message', (msg, rinfo) => {
@@ -180,15 +180,15 @@ Sood.prototype._listen_iface = function(ip, netmask, ifacename) {
     let new_iface = false;
         
     if (!iface.recv_sock) {
-//	this.logger.log(`SOOD: new sock: recv ${ip}/${ifacename}`);
+//	log.debug(`SOOD: new sock: recv ${ip}/${ifacename}`);
         new_iface = true;
 	iface.recv_sock = dgram.createSocket({ type: 'udp4', reuseAddr: true });
 	iface.recv_sock.on('error', (err) => {
-//	    this.logger.log(`server error ${ip}`, err);
+//	    log.debug(`server error ${ip}`, err);
 	    iface.recv_sock.close();
 	});
 	iface.recv_sock.on('close', () => {
-//	    this.logger.log(`closed multicast on ${ip}`);
+//	    log.debug(`closed multicast on ${ip}`);
 	    delete(iface.recv_sock);
 	});
 	iface.recv_sock.on('message', (msg, rinfo) => {
@@ -200,16 +200,16 @@ Sood.prototype._listen_iface = function(ip, netmask, ifacename) {
 	});
     }
     if (!iface.send_sock) {
-//        this.logger.log(`SOOD: new sock: send ${ip}/${ifacename}`);
+//        log.debug(`SOOD: new sock: send ${ip}/${ifacename}`);
         new_iface = true;
 	iface.send_sock = dgram.createSocket({ type: 'udp4' });
         iface.broadcast = IP.subnet(ip, netmask).broadcastAddress;
 	iface.send_sock.on('error', (err) => {
-//	    this.logger.log(`server error ${ip}`, err);
+//	    log.debug(`server error ${ip}`, err);
 	    iface.send_sock.close();
 	});
 	iface.send_sock.on('close', () => {
-//	    this.logger.log(`closed multicast on ${ip}`);
+//	    log.debug(`closed multicast on ${ip}`);
 	    delete(iface.send_sock);
 	});
 	iface.send_sock.on('message', (msg, rinfo) => {
@@ -225,4 +225,4 @@ Sood.prototype._listen_iface = function(ip, netmask, ifacename) {
 
 }
 
-exports = module.exports = function(logger) { return new Sood(logger); };
+exports = module.exports = function() { return new Sood(); };

--- a/transport-websocket.js
+++ b/transport-websocket.js
@@ -1,9 +1,11 @@
 "use strict";
 
+const log = require('./loggers.js');
+
 // polyfill websockets in Node
 if (typeof (WebSocket) == "undefined") global.WebSocket = require('ws');
 
-function Transport(ip, port, logger) {
+function Transport(ip, port) {
     this.host = ip;
     this.port = port;
 
@@ -14,7 +16,6 @@ function Transport(ip, port, logger) {
     if (typeof (window) != "undefined") {
         this.ws.binaryType = 'arraybuffer';
     }
-    this.logger = logger;
 
     this.ws.on('pong', () => this.is_alive = true);
     this.ws.onopen = () => {
@@ -25,7 +26,7 @@ function Transport(ip, port, logger) {
                 return;
             }
             if (this.is_alive === false) {
-                logger.log(`Roon API Connection to ${this.host}:${this.port} closed due to missed heartbeat`);
+                log.warn(`Roon API Connection to ${this.host}:${this.port} closed due to missed heartbeat`);
                 return this.ws.terminate();
             }
             this.is_alive = false;
@@ -44,7 +45,7 @@ function Transport(ip, port, logger) {
     };
 
     this.ws.onerror = (err) => {
-        this.onerror();
+        this.onerror(err);
     }
 
     this.ws.onmessage = (event) => {
@@ -88,7 +89,7 @@ Transport.prototype.close = function () {
 
 Transport.prototype.onopen = function() { };
 Transport.prototype.onclose = function() { };
-Transport.prototype.onerror = function() { };
+Transport.prototype.onerror = function(err) { };
 Transport.prototype.onmessage = function() { };
 
 exports = module.exports = Transport;


### PR DESCRIPTION
The custom logging was quite limited and either logged too much or too little. Use the debug module and remove the log_level parameter in RoonApi.

Defined log levels:
- `roonapi:msg`: message trace of WebSocket communication and SOOD discovery
- `roonapi:debug`
- `roonapi:info`
- `roonapi:warn`
- `roonapi:error`
